### PR TITLE
APE-9649 changing endpoint url for download, push rules api

### DIFF
--- a/src/commands/backendClient.ts
+++ b/src/commands/backendClient.ts
@@ -21,8 +21,8 @@ export class BackendClient {
 
     private _requestTimeout: number = 10000;
     private _client: string = "rego-editor";
-    private _getRulesEndpoint: string = "/v1/api/app/rule";
-    private _pushRulesEndpoint: string = "/v1/api/app/rule";
+    private _getRulesEndpoint: string = "/v1/app/rules";
+    private _pushRulesEndpoint: string = "/v1/app/rule";
     private _header: IHeaders;
 
     constructor(public host: string, public appToken: string) {


### PR DESCRIPTION
Issue: Rego Editor Integration is not working with Tenable cs.

Endpoint url for get_rules and push_rules was changed in siac code and hence while fetching custom policies it was failing. 
Changed the url and similar change is made in siac code to consume long live token.

Verification scenarios on local dev setup - 
- created custom policy from UI and modifying it from RegoEditor.. synced the policy and verified through UI
- created custom policy using RegoEditor from tf file resource and checked similar behaviour through UI
- verified locally terrascan invoked through plugin using above both policies.. scan completed and listed violations.. 