### PR TITLE
Making sure iacPath is json friendly on Win

### DIFF
--- a/src/commands/generateConfig.ts
+++ b/src/commands/generateConfig.ts
@@ -113,7 +113,7 @@ async function generateConfig(context: ExtensionContext, uri: Uri, iacType: stri
                 "terrascanConfig":${configJson},
                 "iacMetadata": {
                     "iacType":"${iacType}",
-                    "iacPath":"${getRelativePath(uri)}",
+                    "iacPath":"${getRelativePath(uri).split(path.sep).join(path.posix.sep)}",
                     "providerType":"${providerType}"
                 }
             }`), null, "\t");


### PR DESCRIPTION
### Reference issue

rego editor generateConfig cmd not working on windows #46

### Description

json is not happy with windows paths because of the backspace "\\" in them is considered an escape char. Changing the path to be posix separated, with "/". Another alternative is to use .replace(/\\\\/g,"\\\\\\\\"). Either way this should fix #46.

### Interesting observation

MarkDown also treats backspace as escape so there needs to be a lot of backspaces for the alternative.